### PR TITLE
Adding functionality for nested modules to be linked

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,7 @@ The key motivator to create `link-module-alias` was to fix the issue with module
 ## License
 
 MIT. Attribution to the `module-alias` for parts for the README and original idea.
+
+# Contributors
+
+[@kwburnett](https://github.com/kwburnett)

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ const chalk = require('chalk');
 
 const linkAliasPrefix = '.link-module-alias-';
 const linkAliasNestedSeparator = '--';
+const DIR_LINK_TYPE = ((process.platform === 'win32') ? 'junction' : 'dir');
 
 async function tryUnlink(path) {
   try {
@@ -176,7 +177,7 @@ async function linkModule(moduleName) {
         }
       }
     }
-    await symlink(path.join('../', target), moduleDir, 'dir');
+    await symlink(path.join('../', target), moduleDir, DIR_LINK_TYPE);
     type = 'symlink';
   }
   await writeFile(path.join('node_modules', getModuleAlias(moduleName)), '');

--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ const rmdir = promisify(fs.rmdir);
 
 const chalk = require('chalk');
 
-const linkAliasPrefix = '.link-module-alias-';
-const linkAliasNestedSeparator = '--';
+const LINK_ALIAS_PREFIX = '.link-module-alias-';
+const LINK_ALIAS_NESTED_SEPARATOR = '--';
 const DIR_LINK_TYPE = ((process.platform === 'win32') ? 'junction' : 'dir');
 
 async function tryUnlink(path) {
@@ -81,13 +81,13 @@ function addColorUnlink({moduleName, type}) {
 
 function getModuleAlias(moduleName) {
   // Replace any nested alias names with "--"
-  return `${linkAliasPrefix}${moduleName.replace(/\//g, linkAliasNestedSeparator)}`;
+  return `${LINK_ALIAS_PREFIX}${moduleName.replace(/\//g, LINK_ALIAS_NESTED_SEPARATOR)}`;
 }
 
 function getModuleNameFromAliasFile(aliasFileName) {
   // See if this matches the prefix and return the module name, if present
-  const m = aliasFileName.match(new RegExp(`^\\${linkAliasPrefix}(.*)`)); // RegExp = /^\.link-module-alias-(.*)/
-  return m && m[1].replace(new RegExp(linkAliasNestedSeparator, 'g'), '/'); // RegExp = /--/g
+  const m = aliasFileName.match(new RegExp(`^\\${LINK_ALIAS_PREFIX}(.*)`)); // RegExp = /^\.link-module-alias-(.*)/
+  return m && m[1].replace(new RegExp(LINK_ALIAS_NESTED_SEPARATOR, 'g'), '/'); // RegExp = /--/g
 }
 
 async function exists(filename) {


### PR DESCRIPTION
This is to deal with [issue 9](https://github.com/Rush/link-module-alias/issues/9). I made updates to replace the file created that's used to track which modules are linked by replacing `/` in the alias with `--`. `symlink` also can't handle nested directories, so I added lines to add all directories except the one to be symlink'd.

Additional work that could be done would be to clean up all sub-directories that are created when cleaning. For example, if two aliases provided are `my/module/1` and `my/module/2`, you would want to remove the `my` and `module` directories after both `1` & `2` had been removed. Right now `my/module` will be left empty in `node_modules`.