### PR TITLE
Added possibility to specify typings field for links to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Note: you can use `@` in front of your module but before of the possible data lo
   "~deep"      : "src/some/very/deep/directory/or/file",
   "@my_module" : "lib/some-file.js", // can be @ - but see above comment and understand the associated risk
   "something"  : "src/foo", // Or without ~. Actually, it could be any string
+  "module-with-typings": {
+    "main": "src/path/to/module.js",
+    "typings" "src/path/to/module/typings.d.ts" // you can specify typings for files (it works with aliases to files only)
+  }
 }
 ```
 


### PR DESCRIPTION
As soon for an alias to a file the tool generates own `package.json`, it might be useful to specify `"typings"` field for such aliases (for example, in case when typings file has different name and/or path).