### PR TITLE
fix for checking if target is a directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,8 +155,8 @@ async function linkModule(moduleName) {
     await writeFile(path.join(moduleDir, 'package.json'), JSON.stringify(packageJsonObj, null, 2));
     type = 'proxy';
   } else {
-    const stat = fs.statSync(target);
-    if(!stat.isDirectory) {
+    const stat = fs.lstatSync(target);
+    if(!stat.isDirectory()) {
       console.log(`Target ${target} is not a directory, skipping ...`);
       type = 'none';
       return { moduleName, type, target };


### PR DESCRIPTION
```
  } else {
    const stat = fs.statSync(target);
    if(!stat.isDirectory) {
      console.log(`Target ${target} is not a directory, skipping ...`);
      type = 'none';
      return { moduleName, type, target };
    }
```
using `fs.statSync` here will return an object that doesn't have isDirectory property, so `if(!stat.isDirectory) {` will always be true in this scope because `stat.isDirectory` is `undefined`.
in order to detect if **target** is actually a directory you need to use `fs.lstatSync(target)` and `stat.isDirectory()` **function**